### PR TITLE
Changes to build in case-insensitive filesystems, builds with Ubuntu.Dockerfile in OSX (arm64) and Ubuntu (amd64)

### DIFF
--- a/library/api/CMakeLists.txt
+++ b/library/api/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_api STATIC)
 # Public include headers
 target_include_directories(minecpp_api
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp
 )
 
 # Source subdirectory

--- a/library/api/src/nbt/block/Block.schema.cpp
+++ b/library/api/src/nbt/block/Block.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/block/Block.schema.h"
+#include <minecpp/nbt/block/Block.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::block {

--- a/library/api/src/nbt/block/BlockState.schema.cpp
+++ b/library/api/src/nbt/block/BlockState.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/block/BlockState.schema.h"
+#include <minecpp/nbt/block/BlockState.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::block {

--- a/library/api/src/nbt/chunk/Chunk.schema.cpp
+++ b/library/api/src/nbt/chunk/Chunk.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/chunk/Chunk.schema.h"
+#include <minecpp/nbt/chunk/Chunk.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::chunk {

--- a/library/api/src/nbt/common/Common.schema.cpp
+++ b/library/api/src/nbt/common/Common.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/common/Common.schema.h"
+#include <minecpp/nbt/common/Common.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::common {

--- a/library/api/src/nbt/item/Item.schema.cpp
+++ b/library/api/src/nbt/item/Item.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/item/Item.schema.h"
+#include <minecpp/nbt/item/Item.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::item {

--- a/library/api/src/nbt/level/Level.schema.cpp
+++ b/library/api/src/nbt/level/Level.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/level/Level.schema.h"
+#include <minecpp/nbt/level/Level.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::level {

--- a/library/api/src/nbt/player/Player.schema.cpp
+++ b/library/api/src/nbt/player/Player.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/player/Player.schema.h"
+#include <minecpp/nbt/player/Player.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::player {

--- a/library/api/src/nbt/repository/Biome.schema.cpp
+++ b/library/api/src/nbt/repository/Biome.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Biome.schema.h"
+#include <minecpp/nbt/repository/Biome.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Chat.schema.cpp
+++ b/library/api/src/nbt/repository/Chat.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Chat.schema.h"
+#include <minecpp/nbt/repository/Chat.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Damage.schema.cpp
+++ b/library/api/src/nbt/repository/Damage.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Damage.schema.h"
+#include <minecpp/nbt/repository/Damage.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Dimension.schema.cpp
+++ b/library/api/src/nbt/repository/Dimension.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Dimension.schema.h"
+#include <minecpp/nbt/repository/Dimension.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Registry.schema.cpp
+++ b/library/api/src/nbt/repository/Registry.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Registry.schema.h"
+#include <minecpp/nbt/repository/Registry.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Repository.schema.cpp
+++ b/library/api/src/nbt/repository/Repository.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Repository.schema.h"
+#include <minecpp/nbt/repository/Repository.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/repository/Trim.schema.cpp
+++ b/library/api/src/nbt/repository/Trim.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/repository/Trim.schema.h"
+#include <minecpp/nbt/repository/Trim.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::repository {

--- a/library/api/src/nbt/trace/Trace.schema.cpp
+++ b/library/api/src/nbt/trace/Trace.schema.cpp
@@ -1,4 +1,4 @@
-#include "nbt/trace/Trace.schema.h"
+#include <minecpp/nbt/trace/Trace.schema.h>
 #include <minecpp/nbt/Exception.h>
 
 namespace minecpp::nbt::trace {

--- a/library/api/src/net/Chunk.schema.cpp
+++ b/library/api/src/net/Chunk.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/Chunk.schema.h"
+#include <minecpp/net/Chunk.schema.h>
 #include <algorithm>
 
 namespace minecpp::net {

--- a/library/api/src/net/Common.schema.cpp
+++ b/library/api/src/net/Common.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/Common.schema.h"
+#include <minecpp/net/Common.schema.h>
 #include <algorithm>
 
 namespace minecpp::net {

--- a/library/api/src/net/engine/Clientbound.schema.cpp
+++ b/library/api/src/net/engine/Clientbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/engine/Clientbound.schema.h"
+#include <minecpp/net/engine/Clientbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::engine::cb {

--- a/library/api/src/net/engine/Serverbound.schema.cpp
+++ b/library/api/src/net/engine/Serverbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/engine/Serverbound.schema.h"
+#include <minecpp/net/engine/Serverbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::engine::sb {

--- a/library/api/src/net/login/Clientbound.schema.cpp
+++ b/library/api/src/net/login/Clientbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/login/Clientbound.schema.h"
+#include <minecpp/net/login/Clientbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::login::cb {

--- a/library/api/src/net/login/Serverbound.schema.cpp
+++ b/library/api/src/net/login/Serverbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/login/Serverbound.schema.h"
+#include <minecpp/net/login/Serverbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::login::sb {

--- a/library/api/src/net/play/Clientbound.schema.cpp
+++ b/library/api/src/net/play/Clientbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/play/Clientbound.schema.h"
+#include <minecpp/net/play/Clientbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::play::cb {

--- a/library/api/src/net/play/Common.schema.cpp
+++ b/library/api/src/net/play/Common.schema.cpp
@@ -1,4 +1,4 @@
-#include "net/play/Common.schema.h"
+#include <minecpp/net/play/Common.schema.h>
 #include "minecpp/network/NetworkUtil.h"
 #include <algorithm>
 

--- a/library/api/src/net/play/Serverbound.schema.cpp
+++ b/library/api/src/net/play/Serverbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/play/Serverbound.schema.h"
+#include <minecpp/net/play/Serverbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::play::sb {

--- a/library/api/src/net/status/Clientbound.schema.cpp
+++ b/library/api/src/net/status/Clientbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/status/Clientbound.schema.h"
+#include <minecpp/net/status/Clientbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::status::cb {

--- a/library/api/src/net/status/Serverbound.schema.cpp
+++ b/library/api/src/net/status/Serverbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/status/Serverbound.schema.h"
+#include <minecpp/net/status/Serverbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::status::sb {

--- a/library/api/src/net/storage/Clientbound.schema.cpp
+++ b/library/api/src/net/storage/Clientbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/storage/Clientbound.schema.h"
+#include <minecpp/net/storage/Clientbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::storage::cb {

--- a/library/api/src/net/storage/Serverbound.schema.cpp
+++ b/library/api/src/net/storage/Serverbound.schema.cpp
@@ -1,5 +1,5 @@
 #include "minecpp/network/NetworkUtil.h"
-#include "net/storage/Serverbound.schema.h"
+#include <minecpp/net/storage/Serverbound.schema.h>
 #include <algorithm>
 
 namespace minecpp::net::storage::sb {

--- a/library/chat/CMakeLists.txt
+++ b/library/chat/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_chat STATIC)
 # Public include headers
 target_include_directories(minecpp_chat
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/chat
 )
 
 # Source subdirectory

--- a/library/command/CMakeLists.txt
+++ b/library/command/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_command STATIC)
 # Public include headers
 target_include_directories(minecpp_command
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/command
 )
 
 # Source subdirectory

--- a/library/command/src/core/Core.cpp
+++ b/library/command/src/core/Core.cpp
@@ -1,18 +1,17 @@
-#include "core/Core.h"
-
-#include "CommandManager.h"
-#include "core/Cord.h"
-#include "core/DecimateBlocks.h"
-#include "core/Echo.h"
-#include "core/Fly.h"
-#include "core/Format.h"
-#include "core/Give.h"
-#include "core/KillAll.h"
-#include "core/ListEntities.h"
-#include "core/ReloadChunk.h"
-#include "core/Spawn.h"
-#include "core/Sync.h"
-#include "core/Teleport.h"
+#include <minecpp/command/core/Core.h>
+#include <minecpp/command/CommandManager.h>
+#include <minecpp/command/core/Cord.h>
+#include <minecpp/command/core/DecimateBlocks.h>
+#include <minecpp/command/core/Echo.h>
+#include <minecpp/command/core/Fly.h>
+#include <minecpp/command/core/Format.h>
+#include <minecpp/command/core/Give.h>
+#include <minecpp/command/core/KillAll.h>
+#include <minecpp/command/core/ListEntities.h>
+#include <minecpp/command/core/ReloadChunk.h>
+#include <minecpp/command/core/Spawn.h>
+#include <minecpp/command/core/Sync.h>
+#include <minecpp/command/core/Teleport.h>
 
 namespace minecpp::command::core {
 

--- a/library/command/src/core/DecimateBlocks.cpp
+++ b/library/command/src/core/DecimateBlocks.cpp
@@ -1,5 +1,5 @@
-#include "core/DecimateBlocks.h"
-#include "RuntimeContext.h"
+#include <minecpp/command/core/DecimateBlocks.h>
+#include <minecpp/command/RuntimeContext.h>
 
 #include "minecpp/entity/Aliases.hpp"
 #include "minecpp/entity/component/Abilities.h"

--- a/library/command/test/CMakeLists.txt
+++ b/library/command/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_command_test)
 # Public include headers
 target_include_directories(minecpp_command_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/command_test
 )
 
 # Source subdirectory

--- a/library/container/CMakeLists.txt
+++ b/library/container/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_container STATIC)
 # Public include headers
 target_include_directories(minecpp_container
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/container
 )
 
 # Source subdirectory

--- a/library/container/test/CMakeLists.txt
+++ b/library/container/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_container_test)
 # Public include headers
 target_include_directories(minecpp_container_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/container_test
 )
 
 # Source subdirectory

--- a/library/controller/CMakeLists.txt
+++ b/library/controller/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_controller STATIC)
 # Public include headers
 target_include_directories(minecpp_controller
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/controller
 )
 
 # Source subdirectory

--- a/library/controller/src/block/Block.cpp
+++ b/library/controller/src/block/Block.cpp
@@ -1,14 +1,14 @@
-#include "block/Block.h"
-#include "block/Door.h"
-#include "block/Fence.h"
-#include "block/Foliage.h"
-#include "block/Grass.h"
-#include "block/Slab.h"
-#include "block/Stairs.h"
-#include "block/Torch.h"
-#include "block/TrapDoor.h"
-#include "block/Wood.h"
-#include "BlockManager.h"
+#include <minecpp/controller/block/Block.h>
+#include <minecpp/controller/block/Door.h>
+#include <minecpp/controller/block/Fence.h>
+#include <minecpp/controller/block/Foliage.h>
+#include <minecpp/controller/block/Grass.h>
+#include <minecpp/controller/block/Slab.h>
+#include <minecpp/controller/block/Stairs.h>
+#include <minecpp/controller/block/Torch.h>
+#include <minecpp/controller/block/TrapDoor.h>
+#include <minecpp/controller/block/Wood.h>
+#include <minecpp/controller/BlockManager.h>
 #include "minecpp/repository/Block.h"
 #include <spdlog/spdlog.h>
 

--- a/library/controller/src/block/Foliage.cpp
+++ b/library/controller/src/block/Foliage.cpp
@@ -1,4 +1,4 @@
-#include "block/Foliage.h"
+#include <minecpp/controller/block/Foliage.h>
 
 #include "minecpp/world/BlockState.h"
 

--- a/library/controller/src/item/Item.cpp
+++ b/library/controller/src/item/Item.cpp
@@ -1,9 +1,9 @@
-#include "item/Item.h"
-#include "item/Bow.h"
-#include "item/Food.h"
-#include "item/Sword.h"
+#include <minecpp/controller/item/Item.h>
+#include <minecpp/controller/item/Bow.h>
+#include <minecpp/controller/item/Food.h>
+#include <minecpp/controller/item/Sword.h>
 #include "minecpp/repository/Item.h"
-#include "RootItem.h"
+#include <minecpp/controller/RootItem.h>
 
 namespace minecpp::controller::item {
 

--- a/library/crypto/CMakeLists.txt
+++ b/library/crypto/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_crypto STATIC)
 # Public include headers
 target_include_directories(minecpp_crypto
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/crypto
 )
 
 # Source subdirectory

--- a/library/crypto/test/CMakeLists.txt
+++ b/library/crypto/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_crypto_test)
 # Public include headers
 target_include_directories(minecpp_crypto_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/crypto_test
 )
 
 # Source subdirectory

--- a/library/debug/CMakeLists.txt
+++ b/library/debug/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_debug STATIC)
 # Public include headers
 target_include_directories(minecpp_debug
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/debug
 )
 
 # Source subdirectory

--- a/library/debug/src/TraceManager.cpp
+++ b/library/debug/src/TraceManager.cpp
@@ -1,4 +1,4 @@
-#include "TraceManager.h"
+#include <minecpp/debug/TraceManager.h>
 
 #include <cassert>
 

--- a/library/debug/test/CMakeLists.txt
+++ b/library/debug/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_debug_test)
 # Public include headers
 target_include_directories(minecpp_debug_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/debug_test
 )
 
 # Source subdirectory

--- a/library/entity/CMakeLists.txt
+++ b/library/entity/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_entity STATIC)
 # Public include headers
 target_include_directories(minecpp_entity
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/entity
 )
 
 # Source subdirectory

--- a/library/entity/test/CMakeLists.txt
+++ b/library/entity/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_entity_test)
 # Public include headers
 target_include_directories(minecpp_entity_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/entity_test
 )
 
 # Source subdirectory

--- a/library/format/CMakeLists.txt
+++ b/library/format/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_format STATIC)
 # Public include headers
 target_include_directories(minecpp_format
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/format
 )
 
 # Source subdirectory

--- a/library/format/test/CMakeLists.txt
+++ b/library/format/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_format_test)
 # Public include headers
 target_include_directories(minecpp_format_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/format_test
 )
 
 # Source subdirectory

--- a/library/game/CMakeLists.txt
+++ b/library/game/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_game STATIC)
 # Public include headers
 target_include_directories(minecpp_game
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/game
 )
 
 # Source subdirectory

--- a/library/game/src/ChunkRange.cpp
+++ b/library/game/src/ChunkRange.cpp
@@ -1,4 +1,4 @@
-#include "ChunkRange.h"
+#include <minecpp/game/ChunkRange.h>
 
 namespace minecpp::game {
 

--- a/library/game/src/SectionRange.cpp
+++ b/library/game/src/SectionRange.cpp
@@ -1,5 +1,5 @@
-#include "SectionRange.h"
-#include "ChunkRange.h"
+#include <minecpp/game/SectionRange.h>
+#include <minecpp/game/ChunkRange.h>
 
 namespace minecpp::game {
 

--- a/library/game/test/CMakeLists.txt
+++ b/library/game/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_game_test)
 # Public include headers
 target_include_directories(minecpp_game_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/game_test
 )
 
 # Source subdirectory

--- a/library/lexer/CMakeLists.txt
+++ b/library/lexer/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_lexer STATIC)
 # Public include headers
 target_include_directories(minecpp_lexer
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/lexer
 )
 
 # Source subdirectory

--- a/library/lexer/example/python/CMakeLists.txt
+++ b/library/lexer/example/python/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_lexer_example_python)
 # Public include headers
 target_include_directories(minecpp_lexer_example_python
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/lexer_example_python
 )
 
 # Source subdirectory

--- a/library/lexer/src/IStreamReader.cpp
+++ b/library/lexer/src/IStreamReader.cpp
@@ -1,4 +1,4 @@
-#include "IStreamReader.h"
+#include <minecpp/lexer/IStreamReader.h>
 
 namespace minecpp::lexer {
 

--- a/library/math/test/CMakeLists.txt
+++ b/library/math/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_math_test)
 # Public include headers
 target_include_directories(minecpp_math_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/math_test
 )
 
 # Source subdirectory

--- a/library/nbt/CMakeLists.txt
+++ b/library/nbt/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_nbt STATIC)
 # Public include headers
 target_include_directories(minecpp_nbt
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/nbt
 )
 
 # Source subdirectory

--- a/library/nbt/test/CMakeLists.txt
+++ b/library/nbt/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_nbt_test)
 # Public include headers
 target_include_directories(minecpp_nbt_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/nbt_test
 )
 
 # Source subdirectory

--- a/library/network/CMakeLists.txt
+++ b/library/network/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_network STATIC)
 # Public include headers
 target_include_directories(minecpp_network
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/network
 )
 
 # Source subdirectory

--- a/library/network/src/Network.cpp
+++ b/library/network/src/Network.cpp
@@ -1,4 +1,4 @@
-#include "Network.h"
+#include <minecpp/network/Network.h>
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>

--- a/library/network/src/NetworkUtil.cpp
+++ b/library/network/src/NetworkUtil.cpp
@@ -1,4 +1,4 @@
-#include "NetworkUtil.h"
+#include <minecpp/network/NetworkUtil.h>
 
 namespace minecpp::network {
 

--- a/library/network/test/CMakeLists.txt
+++ b/library/network/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_network_test)
 # Public include headers
 target_include_directories(minecpp_network_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/network_test
 )
 
 # Source subdirectory

--- a/library/random/CMakeLists.txt
+++ b/library/random/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_random STATIC)
 # Public include headers
 target_include_directories(minecpp_random
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/random
 )
 
 # Source subdirectory

--- a/library/random/test/CMakeLists.txt
+++ b/library/random/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_random_test)
 # Public include headers
 target_include_directories(minecpp_random_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/random_test
 )
 
 # Source subdirectory

--- a/library/region/CMakeLists.txt
+++ b/library/region/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_region STATIC)
 # Public include headers
 target_include_directories(minecpp_region
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/region
 )
 
 # Source subdirectory

--- a/library/repository/CMakeLists.txt
+++ b/library/repository/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_repository STATIC)
 # Public include headers
 target_include_directories(minecpp_repository
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/repository
 )
 
 # Source subdirectory

--- a/library/repository/test/CMakeLists.txt
+++ b/library/repository/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_repository_test)
 # Public include headers
 target_include_directories(minecpp_repository_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/repository_test
 )
 
 # Source subdirectory

--- a/library/stream/CMakeLists.txt
+++ b/library/stream/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_stream STATIC)
 # Public include headers
 target_include_directories(minecpp_stream
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/stream
 )
 
 # Source subdirectory

--- a/library/stream/example/client/CMakeLists.txt
+++ b/library/stream/example/client/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_stream_example_client)
 # Public include headers
 target_include_directories(minecpp_stream_example_client
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/stream_example_client
 )
 
 # Source subdirectory

--- a/library/stream/example/server/CMakeLists.txt
+++ b/library/stream/example/server/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_stream_example_server)
 # Public include headers
 target_include_directories(minecpp_stream_example_server
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/stream_example_server
 )
 
 # Source subdirectory

--- a/library/stream/src/Client.cpp
+++ b/library/stream/src/Client.cpp
@@ -1,4 +1,4 @@
-#include "Client.h"
+#include <minecpp/stream/Client.h>
 
 #include <boost/endian.hpp>
 #include <enet/enet.h>

--- a/library/stream/src/Host.cpp
+++ b/library/stream/src/Host.cpp
@@ -1,4 +1,4 @@
-#include "Host.h"
+#include <minecpp/stream/Host.h>
 
 #include "minecpp/container/BasicBuffer.hpp"
 

--- a/library/stream/src/Peer.cpp
+++ b/library/stream/src/Peer.cpp
@@ -1,5 +1,5 @@
-#include "Peer.h"
-#include "Host.h"
+#include <minecpp/stream/Peer.h>
+#include <minecpp/stream/Host.h>
 
 #include "minecpp/container/BasicBuffer.hpp"
 

--- a/library/stream/src/Server.cpp
+++ b/library/stream/src/Server.cpp
@@ -1,4 +1,4 @@
-#include "Server.h"
+#include <minecpp/stream/Server.h>
 
 #include <enet/enet.h>
 

--- a/library/util/CMakeLists.txt
+++ b/library/util/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_utils STATIC)
 # Public include headers
 target_include_directories(minecpp_utils
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/util
 )
 
 # Source subdirectory

--- a/library/util/src/Context.cpp
+++ b/library/util/src/Context.cpp
@@ -1,4 +1,4 @@
-#include "Context.h"
+#include <minecpp/util/Context.h>
 
 #include <atomic>
 

--- a/library/util/src/Threading.cpp
+++ b/library/util/src/Threading.cpp
@@ -1,4 +1,4 @@
-#include "Threading.h"
+#include <minecpp/util/Threading.h>
 
 #ifdef unix
 #include <pthread.h>

--- a/library/util/test/CMakeLists.txt
+++ b/library/util/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_utils_test)
 # Public include headers
 target_include_directories(minecpp_utils_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/util_test
 )
 
 # Source subdirectory

--- a/library/world/CMakeLists.txt
+++ b/library/world/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_world STATIC)
 # Public include headers
 target_include_directories(minecpp_world
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/world
 )
 
 # Source subdirectory

--- a/library/world/src/ChunkSerializer.cpp
+++ b/library/world/src/ChunkSerializer.cpp
@@ -1,7 +1,6 @@
-#include "ChunkSerializer.h"
-
-#include "Chunk.h"
-#include "Section.h"
+#include <minecpp/world/ChunkSerializer.h>
+#include <minecpp/world/Chunk.h>
+#include <minecpp/world/Section.h>
 
 #include "minecpp/math/Vector2.h"
 

--- a/library/world/src/Section.cpp
+++ b/library/world/src/Section.cpp
@@ -1,7 +1,7 @@
-#include "Section.h"
+#include <minecpp/world/Section.h>
 
-#include "BlockState.h"
-#include "Util.h"
+#include <minecpp/world/BlockState.h>
+#include <minecpp/world/Util.h>
 
 #include "minecpp/util/Packed.h"
 

--- a/library/world/test/CMakeLists.txt
+++ b/library/world/test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_world_test)
 # Public include headers
 target_include_directories(minecpp_world_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/world_test
 )
 
 # Source subdirectory

--- a/meta/cmake-generate-target.sh
+++ b/meta/cmake-generate-target.sh
@@ -61,7 +61,6 @@ function generate_cmake_target() {
   else
     echo "target_include_directories($targetname"
     echo "  PUBLIC \${CMAKE_CURRENT_SOURCE_DIR}/include"
-    echo "  PRIVATE \${CMAKE_CURRENT_SOURCE_DIR}/include/$include_path"
     echo ")"
     echo ""
     echo "# Source subdirectory"

--- a/service/engine/CMakeLists.txt
+++ b/service/engine/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_engine)
 # Public include headers
 target_include_directories(minecpp_engine
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/engine
 )
 
 # Source subdirectory

--- a/service/engine/api/CMakeLists.txt
+++ b/service/engine/api/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_engine_api STATIC)
 # Public include headers
 target_include_directories(minecpp_engine_api
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/service/engine
 )
 
 # Source subdirectory

--- a/service/engine/api/src/Api.cpp
+++ b/service/engine/api/src/Api.cpp
@@ -1,4 +1,4 @@
-#include "Api.h"
+#include <minecpp/service/engine/Api.h>
 
 #include "minecpp/container/BasicBuffer.hpp"
 

--- a/service/front/CMakeLists.txt
+++ b/service/front/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_front)
 # Public include headers
 target_include_directories(minecpp_front
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/front
 )
 
 # Source subdirectory

--- a/service/storage/CMakeLists.txt
+++ b/service/storage/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_storage)
 # Public include headers
 target_include_directories(minecpp_storage
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/storage
 )
 
 # Source subdirectory

--- a/service/storage/api/CMakeLists.txt
+++ b/service/storage/api/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(minecpp_storage_api STATIC)
 # Public include headers
 target_include_directories(minecpp_storage_api
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/service/storage
 )
 
 # Source subdirectory

--- a/service/storage/example/api_test/CMakeLists.txt
+++ b/service/storage/example/api_test/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_storage_example_api_test)
 # Public include headers
 target_include_directories(minecpp_storage_example_api_test
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/storage_example_api_test
 )
 
 # Source subdirectory

--- a/service/storage/example/fdb_request/CMakeLists.txt
+++ b/service/storage/example/fdb_request/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_storage_fdb_request)
 # Public include headers
 target_include_directories(minecpp_storage_fdb_request
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/storage_example_fdb_request
 )
 
 # Source subdirectory

--- a/tool/chunk_extractor/CMakeLists.txt
+++ b/tool/chunk_extractor/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_chunk_extractor)
 # Public include headers
 target_include_directories(minecpp_chunk_extractor
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/chunk_extractor
 )
 
 # Source subdirectory

--- a/tool/chunk_viewer/CMakeLists.txt
+++ b/tool/chunk_viewer/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_chunk_viewer)
 # Public include headers
 target_include_directories(minecpp_chunk_viewer
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/chunk_viewer
 )
 
 # Source subdirectory

--- a/tool/nbt_viewer/CMakeLists.txt
+++ b/tool/nbt_viewer/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_nbt_viewer)
 # Public include headers
 target_include_directories(minecpp_nbt_viewer
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/nbt_viewer
 )
 
 # Source subdirectory

--- a/tool/nbtscheme/CMakeLists.txt
+++ b/tool/nbtscheme/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_nbtscheme)
 # Public include headers
 target_include_directories(minecpp_nbtscheme
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/nbtscheme
 )
 
 # Source subdirectory

--- a/tool/recipes/CMakeLists.txt
+++ b/tool/recipes/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_recipes)
 # Public include headers
 target_include_directories(minecpp_recipes
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/recipes
 )
 
 # Source subdirectory

--- a/tool/schema_compiler/CMakeLists.txt
+++ b/tool/schema_compiler/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_schema_compiler)
 # Public include headers
 target_include_directories(minecpp_schema_compiler
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/schema_compiler
 )
 
 # Source subdirectory

--- a/tool/schema_compiler/example/nbt_generator/CMakeLists.txt
+++ b/tool/schema_compiler/example/nbt_generator/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_schema_compiler_example_nbt_generator)
 # Public include headers
 target_include_directories(minecpp_schema_compiler_example_nbt_generator
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/schema_compiler_example_nbt_generator
 )
 
 # Source subdirectory

--- a/tool/schema_compiler/example/net_generator/CMakeLists.txt
+++ b/tool/schema_compiler/example/net_generator/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_schema_compiler_example_net_generator)
 # Public include headers
 target_include_directories(minecpp_schema_compiler_example_net_generator
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/schema_compiler_example_net_generator
 )
 
 # Source subdirectory

--- a/tool/snbt_parser/CMakeLists.txt
+++ b/tool/snbt_parser/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_tool_snbt_parser)
 # Public include headers
 target_include_directories(minecpp_tool_snbt_parser
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/snbt_parser
 )
 
 # Source subdirectory

--- a/tool/trace_tool/CMakeLists.txt
+++ b/tool/trace_tool/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(minecpp_trace_tool)
 # Public include headers
 target_include_directories(minecpp_trace_tool
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/trace_tool
 )
 
 # Source subdirectory

--- a/tool/trace_tool/src/Main.cpp
+++ b/tool/trace_tool/src/Main.cpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <iomanip> // for std::put_time
 
 using minecpp::nbt::CompoundContent;
 


### PR DESCRIPTION
Hi @mmbednarek,

Here are the changes to allow the project to build with Ubuntu.Dockerfile in both OSX (arm64), which by default has a case-insensitive file system while still building in Ubuntu (amd64).

The motivation of this change is to eliminate the clashes of header files on `#include` directives on case insensitive file systems. Example, on `#include <cstring>`, inside it will try to `#include <string.h>`, but instead of picking up the stand library's `string.h`, it will pick up `minecpp/util/String.h`. This happens because the system includes go last when compiling and because of the following CMake configuration in `minecpp/library/util/CMakeLists.txt`:

```
# Public include headers
target_include_directories(minecpp_utils
  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/minecpp/util  # <-- this line makes String.h be picked up instead of standard library's string.h
)
```

This PR updates on `meta/cmake-generate-target.sh` and all the include directives needed for the project to fully build. Because there are many files, the most important change was to remove the following line on `cmake-generate-target.sh`:
```
    echo "target_include_directories($targetname"
    echo "  PUBLIC \${CMAKE_CURRENT_SOURCE_DIR}/include"
    echo "  PRIVATE \${CMAKE_CURRENT_SOURCE_DIR}/include/$include_path" # <-- removing this line
    echo ")"
    echo ""
    echo "# Source subdirectory"
```

Then run `meta/cmake-generate.sh` and update the header files accordingly for a successful build.

Now the project can be developed in OSX (arm64) through docker, but I'm still evaluating the effort to perform a native build.

Thanks once again for allowing me to learn with this code base.