### PR TITLE
Fixed trace_tool/src/Main.cpp compilation error in ubuntu-latest docker image of github workflow

### DIFF
--- a/tool/trace_tool/src/Main.cpp
+++ b/tool/trace_tool/src/Main.cpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <iomanip> // for std::put_time
 
 using minecpp::nbt::CompoundContent;
 


### PR DESCRIPTION
Compilation was failing in the github workflow with the below error message. Github workflow is using ubuntu-latest docker image.

Error message this commit fixes:

```
error: no member named 'put_time' in namespace 'std'
   return std::put_time(std::localtime(&c_time), "%FT%T%z");
```